### PR TITLE
Added jshint javascript lint tool to gulp.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,9 @@ gulp.task('js', function() {
   var html = gulp.src('demo/**/!(index)*.html')
     .pipe(plugins.angularTemplatecache({standalone: true}));
   
-  var js = gulp.src('demo/**/*.js');
+  var js = gulp.src('demo/**/*.js')
+    .pipe(plugins.jshint())
+    .pipe(plugins.jshint.reporter('jshint-stylish'));
   
   return merge(js, html)
     .pipe(plugins.concat('demo.js'))

--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
     "gulp-filter": "^4.0.0",
     "gulp-inject": "^4.1.0",
     "gulp-insert": "^0.5.0",
+    "gulp-jshint": "^2.0.4",
     "gulp-load-plugins": "^1.2.4",
     "gulp-main-bower-files": "^1.5.2",
     "gulp-ng-annotate": "^2.0.0",
     "gulp-using": "^0.1.1",
+    "jshint": "^2.9.5",
+    "jshint-stylish": "^2.2.1",
     "merge-stream": "^1.0.0"
   }
 }


### PR DESCRIPTION
I've added jshint to the gulp `src` task. You need to run `npm install` to install the new dependencies.