### PR TITLE
Feature/fdp cache persistence

### DIFF
--- a/demo/cache/cache-controller.js
+++ b/demo/cache/cache-controller.js
@@ -1,8 +1,26 @@
-app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Log) {    
+app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Log, HttpEndpoint, File) {    
   $scope.isCachingStarted = false;
   $scope.fairDataPoints=[{name: "RD connect FDP", url:"http://localhost:8084/fairdatapoint/fdp"}];
   $scope.searchEngineUrl=null;
   
+  // populate the list with data from the db
+  var populateCacheList = function() {
+    File.read('data/query/listCachedFdps.sparql').then(function(query) {
+      HttpEndpoint.query(query).then(function(response) {
+        response.data.results.bindings.forEach(function(binding) {
+          $scope.fairdatapoint.push({
+            url: binding.fdp.value,
+            name: binding.name.value
+          });
+        });
+      });
+    });
+  };
+
+  console.log('calling init function');
+  populateCacheList();
+  console.log('init function finished');
+
   $scope.addFdp = function () {
     $scope.fairDataPoints.push({ 
       url: "", name:""

--- a/demo/cache/cache-controller.js
+++ b/demo/cache/cache-controller.js
@@ -1,6 +1,5 @@
 app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Log, HttpEndpoint, File) {    
   $scope.isCachingStarted = false;
-  $scope.fairDataPoints=[{name: "RD connect FDP", url:"http://localhost:8084/fairdatapoint/fdp"}];
   $scope.searchEngineUrl=null;
   
   // populate the list with data from the db
@@ -8,11 +7,20 @@ app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Lo
     File.read('data/query/listCachedFdps.sparql').then(function(query) {
       HttpEndpoint.query(query).then(function(response) {
         response.data.results.bindings.forEach(function(binding) {
-          $scope.fairdatapoint.push({
+          $scope.fairDataPoints.push({
             url: binding.fdp.value,
             name: binding.name.value
           });
         });
+        return $scope.fairDataPoints;
+      }).then(function(fdps) {
+        // if no data was cached, add a default FDP
+        if (fdps.length == 0) {
+          $scope.fairDataPoints = [{
+            name: "RD connect FDP",
+            url:"http://localhost:8084/fairdatapoint/fdp"
+          }];
+        }
       });
     });
   };

--- a/demo/cache/cache-controller.js
+++ b/demo/cache/cache-controller.js
@@ -1,7 +1,7 @@
 app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Log, HttpEndpoint, File) {    
   $scope.isCachingStarted = false;
   $scope.fairDataPoints = [];
-  $scope.searchEngineUrl=null;
+  $scope.searchEngineUrl = null;
   
   // populate the list with data from the db
   var populateCacheList = function() {

--- a/demo/cache/cache-controller.js
+++ b/demo/cache/cache-controller.js
@@ -1,5 +1,6 @@
 app.controller('CacheCtrl', function($scope, $rootScope, $http, FDP, Caching, Log, HttpEndpoint, File) {    
   $scope.isCachingStarted = false;
+  $scope.fairDataPoints = [];
   $scope.searchEngineUrl=null;
   
   // populate the list with data from the db

--- a/sparqlQueries/listCachedFdps.sparql
+++ b/sparqlQueries/listCachedFdps.sparql
@@ -2,6 +2,6 @@ PREFIX r3d: <http://www.re3data.org/schema/3-0#>
 PREFIX dct: <http://purl.org/dc/terms/>
 
 SELECT DISTINCT ?fdp ?name {
-    ?fdp r3d:dataCatalog ?catalog ;
+    ?fdp a r3d:Repository ;
         dct:title ?name .
 }

--- a/sparqlQueries/listCachedFdps.sparql
+++ b/sparqlQueries/listCachedFdps.sparql
@@ -1,0 +1,7 @@
+PREFIX r3d: <http://www.re3data.org/schema/3-0#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?fdp ?name {
+    ?fdp r3d:dataCatalog ?catalog ;
+        dct:title ?name .
+}


### PR DESCRIPTION
Functionality as intended in DEM9, "As a user, I want to have FDPs that are cached in the demonstrator, persisted...". The data is taken from blazegraph, and a simple query is done to list all known FDPs. I have had some issued running it properly locally, so if you see the chance please fork this locally and run it before merging this.

This PR will have to be updated after PR #8 and PR #9 are accepted and merged.

Also, I'm try to see if I can merge from my feature branch directly into the origin develop branch. While creating the PR, github warns it cannot be merged automatically.